### PR TITLE
Allow using various metrics from NearestNeighbors.

### DIFF
--- a/src/embedding.jl
+++ b/src/embedding.jl
@@ -12,6 +12,8 @@ Return a data frame with X,Y coordinates of EmbedSOM projection of the data.
   approximations)
 - `smooth`: approximation smoothness (the higher the value, the larger the
   neighborhood of approximate local linearity of the projection)
+- `knnTreeFun`: Constructor of the KNN-tree (e.g. from NearestNeighbors package)
+- `metric`: Passed as metric argument to the KNN-tree constructor
 
 Example:
 
@@ -35,6 +37,7 @@ and will be normalised with the same parameters.
 """
 function embedGigaSOM(som::GigaSOM.Som, data::DataFrame;
                       knnTreeFun = BruteTree,
+                      metric = Euclidean(),
                       k::Int64=0, adjust::Float64=1.0, smooth::Float64=0.0)
 
     data::Array{Float64,2} = convertTrainingData(data)
@@ -57,7 +60,7 @@ function embedGigaSOM(som::GigaSOM.Som, data::DataFrame;
     end
 
     # prepare the kNN-tree for lookups
-    tree = knnTreeFun(Array{Float64,2}(transpose(som.codes)))
+    tree = knnTreeFun(Array{Float64,2}(transpose(som.codes)), metric)
 
     # run the distributed computation
     nWorkers = nprocs()


### PR DESCRIPTION
Closes #68 .

Quite importantly, cosine distance is still not implemented there (which is IMHO right -- it's not a metric and doesn't really work with e.g. BallTrees, and its applicability to SOMs is in fact disputable at best). A suitable and good alternative for cosine "metric" is squashing the dataset to the unit sphere manually, and using the default Euclidean metric.