### PR TITLE
add mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+#
+# This list is used by git-shortlog to fix a few botched name translations
+# in the git archive, either because the author's full name was messed up
+# and/or not always written the same way, making contributions from the
+# same person appearing not to be so.
+#
+# Proper Name <proper@email.xx> Commit Name <commit@email.xx>
+
+Laurent Heirendt <laurent.heirendt@uni.lu> laurentheirendt <laurent.heirendt@uni.lu>
+Mirek Kratochvil <exa.exa@gmail.com>
+Vasco VERISSIMO <vasco.verissimo@uni.lu> VascoVerissimo <vasco.verissimo@uni.lu>
+oHunewald <o.hunewald@gmail.com> oHunewald <oliver.hunewald@lih.lu> ohunewald <oliver.hunewald@lih.lu>


### PR DESCRIPTION
This list is used by git-shortlog to fix a few botched name translations in the git archive, either because the author's full name was messed up and/or not always written the same way, making contributions from the same person appearing not to be so.