### PR TITLE
Fix performance regression (using DataFrames in low-level code)

### DIFF
--- a/src/embedding.jl
+++ b/src/embedding.jl
@@ -128,7 +128,7 @@ function embedGigaSOM(som::GigaSOM.Som,
 
         return vcat([fetch(r) for r in dRes]...)
     else
-        return embedGigaSOM_internal(som, data, tree, k, adjust, boost, m)
+        return embedGigaSOM_internal(som, Matrix{Float64}(data), tree, k, adjust, boost, m)
     end
 end
 
@@ -145,7 +145,7 @@ Internal function to compute parts of the embedding on a prepared kNN-tree
 structure (`tree`) and `smooth` converted to `boost`.
 """
 function embedGigaSOM_internal(som::GigaSOM.Som,
-                               data,
+                               data::Matrix{Float64},
                                tree,
                                k::Int64,
                                adjust::Float64,


### PR DESCRIPTION
Dataframe indexing seems to always do allocation, which gets terribly slow in EmbedSOM code.

```
julia> @time e = embedGigaSOMX(som, fs,k=7, adjust=5.0)                   # this is with dataframes internally
 13.341578 seconds (227.27 M allocations: 3.450 GiB, 4.40% gc time)
julia> @time e = embedGigaSOMY(som, fs,k=7, adjust=5.0)                   # this is with Matrix
  1.806177 seconds (981.06 k allocations: 100.530 MiB, 0.26% gc time)
```

This fix makes sure that plain dataframes never reach embedGigaSOM_internal.