### PR TITLE
make readFlowFrame work on FCSs from common flow-based machines

### DIFF
--- a/src/io/input.jl
+++ b/src/io/input.jl
@@ -45,20 +45,24 @@ function readFlowFrame(filename::String)
     #flowFrame = Dict()
 
     # read single FCS file into flowFrame
-    flowrun = FileIO.load(filename) # FCS file
+    fcs = FileIO.load(filename) # FCS file
 
     # get metadata
     # FCSFiles returns a dict with coumn names as key
     # As the dict is not in order, use the name column form meta
     # to sort the Dataframe after cast.
-    meta = getMetaData(flowrun)
-    markers = meta[!, Symbol("\$PnS")]
-    markersIsotope = meta[!, Symbol("\$PnN")]
-    # if marker labels are empty use Isotope marker as column names
-    if markers[1] == " "
-        markers = markersIsotope
+    meta = getMetaData(fcs)
+    markersIsotope = Array{String}(meta[!, :N])
+    # collect better marker names
+    markers = copy(markersIsotope)
+    if hasproperty(meta, :S)
+        for i in 1:size(meta,1)
+            if meta[i, :S] != ""
+                markers[i] = meta[i, :S]
+            end
+        end
     end
-    flowDF = DataFrame(flowrun.data)
+    flowDF = DataFrame(fcs.data)
     # sort the DF according to the marker list
     flowDF = flowDF[:, Symbol.(markersIsotope)]
     cleanNames!(markers)

--- a/src/io/process.jl
+++ b/src/io/process.jl
@@ -248,10 +248,7 @@ function getMetaData(f)
             while i<=length(key) && isdigit(key[i])
                 i+=1
             end
-            if i>length(key)
-                continue
-            end
-            if !in(key[i:end], channel_properties)
+            if i<=length(key) && !in(key[i:end], channel_properties)
                 push!(channel_properties, key[i:end])
             end
         end


### PR DESCRIPTION
I had to cleanup the logic of data frame annotation loading, so that it works on files from flow machines. The FCS files from e.g. LSRFortessa (and many others) miss anotations on several $PnS columns (usually scatters+time), which in turn resulted in GigaSOM throwing an index error.

@oHunewald to me it seems this doesn't change the names of the columns in case of CyTOF data from the previous version, but it would be great if you could verify that. :]