### PR TITLE
implement load-time columns selection

### DIFF
--- a/src/GigaSOM.jl
+++ b/src/GigaSOM.jl
@@ -63,6 +63,7 @@ module GigaSOM
         getFCSSize,
         loadFCSSizes,
         loadFCSSet,
+        selectFCSColumns,
         distributeFCSFileVector,
         distributeFileVector
 

--- a/test/testLoadPBMC8.jl
+++ b/test/testLoadPBMC8.jl
@@ -73,3 +73,10 @@ dscale(di, cols)
 pbmc8_data = distributed_collect(di)
 undistribute(di)
 
+@testset "load-time columns normalization" begin
+    di=loadFCSSet(:fcsData, md[:,:file_name], [myid()], postLoad=selectFCSColumns(antigens))
+    dtransform_asinh(di, cols, 5)
+    dscale(di, cols)
+    @test pbmc8_data == distributed_collect(di)
+    undistribute(di)
+end


### PR DESCRIPTION
This helps with dealing with various irregular data. The `postLoad` function is parametrizable for `loadFCSSet` so the users can stick in any column selection method they like; additionally there's the obvious `selectFCSColumns` which does a simple (but useful) selection by name.

