### PR TITLE
fix compathelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,7 +14,7 @@ jobs:
           import Pkg
           name = "CompatHelper"
           uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
-          version = "2"
+          version = "3"
           Pkg.add(; name, uuid, version)
         shell: julia --color=yes {0}
       - name: "Run CompatHelper"


### PR DESCRIPTION
CompatHelper needs version bump in order to continue working correctly with jl 1.8.

Workflow success here:
https://github.com/LCSB-BioCore/GigaSOM.jl/runs/8064942617

Previous workflow fails can be seen eg here:
https://github.com/LCSB-BioCore/GigaSOM.jl/runs/8061694827

Due to completely CI-only nature of this I suggest skipping develop to avoid the overhead and merge right into master.